### PR TITLE
smells: missing union type abstraction

### DIFF
--- a/lib/smells/missing-union-type-abstraction.ts
+++ b/lib/smells/missing-union-type-abstraction.ts
@@ -1,0 +1,63 @@
+import { ParseResult } from "@babel/parser";
+import traverse from "@babel/traverse";
+import { File } from "@babel/types";
+import { SourceLocation } from "../types";
+
+type Union = {
+  members: string[];
+} & SourceLocation;
+
+export const missingUnionTypeAbstraction = (ast: ParseResult<File>) => {
+  const unionTypes: Union[] = [];
+
+  const membersCount: Record<string, number> = {};
+
+  traverse(ast, {
+    TSUnionType(path) {
+      unionTypes.push({
+        members: path.node.types.map((typeNode) => {
+          if (typeNode.literal) {
+            return typeNode.literal.value
+          }
+
+          return typeNode.type === "TSTypeReference" ? typeNode.typeName.name : typeNode.type
+        }),
+        start: path.node.types.find((typeNode) => {
+          if(typeNode.literal) {
+            return typeNode.literal.loc.start.line;
+          }
+
+          return typeNode.type === "TSTypeReference" ? typeNode.typeName.loc?.start.line : typeNode.loc?.start.line;
+        })?.loc?.start.line,
+        end: path.node.types.find((typeNode) => {
+          if(typeNode.literal) {
+            return typeNode.literal.loc.end.line;
+          }
+
+          return typeNode.type === "TSTypeReference" ? typeNode.typeName.loc?.end.line : typeNode.loc?.end.line;
+        })?.loc?.start.line,
+        filename: path.node.types.find((typeNode) => {
+          if(typeNode.literal) {
+            return typeNode.literal.loc.filename;
+          }
+
+          return typeNode.type === "TSTypeReference" ? typeNode.typeName.loc?.filename : typeNode.loc?.filename;
+        })?.loc?.filename
+      });
+    }
+  });
+
+  if (unionTypes.length >= 3) {
+    unionTypes.forEach((union) => {
+      const normalizedMembers = union.members.sort();
+      const key = normalizedMembers.join("|");
+      membersCount[key] = (membersCount[key] ?? 0) + 1;
+    })
+
+    const hasThreeOrMoreDuplicatedUnions = Object.values(membersCount).some(count => count >= 3)
+
+    return hasThreeOrMoreDuplicatedUnions ? unionTypes : [];
+  }
+
+  return [];
+}

--- a/lib/utils/file-reader.ts
+++ b/lib/utils/file-reader.ts
@@ -5,6 +5,7 @@ import { parseAST } from "./parser";
 
 import { anyType } from "../smells/any-type";
 import { nonNullAssertions } from "../smells/non-null-assertions";
+import { missingUnionTypeAbstraction } from "../smells/missing-union-type-abstraction";
 
 async function* readFiles(dirname: string): AsyncGenerator<TSXFile> {
   if(!(await fs.access(dirname).then(() => true).catch(() => false))) {
@@ -34,7 +35,9 @@ export async function processFiles(path: string) {
 
     const anyTypeSmells = anyType(ast);
     const nonNullSmells = nonNullAssertions(ast);
+    const missingUnionSmells = missingUnionTypeAbstraction(ast);
     console.log(anyTypeSmells);
     console.log(nonNullSmells);
+    console.log(missingUnionSmells);
   }
 }

--- a/test/components/MissingUnion.tsx
+++ b/test/components/MissingUnion.tsx
@@ -1,0 +1,12 @@
+const ShapeComponent = () => {
+  const [current, setCurrent] = 
+    useState<'circle' | 'square'>('circle');
+
+  function changeShape(type: 'circle' | 'square') {
+    // ...
+  }
+
+  function calculateArea(type: 'circle' | 'square') {
+    // ...
+  }
+}

--- a/test/missing-union-type-abstraction.spec.ts
+++ b/test/missing-union-type-abstraction.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+import { parseAST } from "../lib/utils/parser";
+import { mockMissingUnionTypeAbstraction } from "./mocks/code-smells-mock";
+import { missingUnionTypeAbstraction } from "../lib/smells/missing-union-type-abstraction";
+
+describe("Missing Union Type Abstraction", () => {
+  test("should return a occurrence of Missing Union Type Abstraction", () => {
+    const expectedOutput = [
+      {
+        members: [ 'circle', 'square' ],
+        start: 3,
+        end: 3,
+        filename: 'test/components/MissingUnion.tsx'
+      },
+      {
+        members: [ 'circle', 'square' ],
+        start: 5,
+        end: 5,
+        filename: 'test/components/MissingUnion.tsx'
+      },
+      {
+        members: [ 'circle', 'square' ],
+        start: 9,
+        end: 9,
+        filename: 'test/components/MissingUnion.tsx'
+      }
+    ];
+
+    const ast = parseAST(mockMissingUnionTypeAbstraction);
+
+    expect(missingUnionTypeAbstraction(ast)).toEqual(expectedOutput);
+  });
+});

--- a/test/mocks/code-smells-mock.ts
+++ b/test/mocks/code-smells-mock.ts
@@ -38,3 +38,19 @@ export const mockNonNullAssertions = {
     '  )\n' +
     '}'
 }
+
+export const mockMissingUnionTypeAbstraction = {
+  path: 'test/components/MissingUnion.tsx',
+  content: 'const ShapeComponent = () => {\n' +
+    '  const [current, setCurrent] = \n' +
+    "    useState<'circle' | 'square'>('circle');\n" +
+    '\n' +
+    "  function changeShape(type: 'circle' | 'square') {\n" +
+    '    // ...\n' +
+    '  }\n' +
+    '\n' +
+    "  function calculateArea(type: 'circle' | 'square') {\n" +
+    '    // ...\n' +
+    '  }\n' +
+    '}'
+}


### PR DESCRIPTION
## Context

The `missingUnionTypeAbstraction` function traverses the AST in seach of nodes that possess TSUnionType as their type. Then, map the members and calculate the thresholds.