### PR TITLE
smells: enum implicit values

### DIFF
--- a/lib/smells/enum-implicit-values.ts
+++ b/lib/smells/enum-implicit-values.ts
@@ -1,0 +1,24 @@
+import { ParseResult } from "@babel/parser";
+import traverse from "@babel/traverse";
+import { File } from "@babel/types";
+import { SourceLocation } from "../types";
+
+export const enumImplicitValues = (ast: ParseResult<File>) => {
+  const enums: SourceLocation[] = [];
+  
+  traverse(ast, {
+    TSEnumDeclaration(path) {
+      const hasAllMembersWithConstants = path.node.members.every((member) => member.initializer);
+
+      if(!hasAllMembersWithConstants) {
+        enums.push({
+          start: path.node.loc?.start.line,
+          end: path.node.loc?.end.line,
+          filename: path.node.loc?.filename
+        });
+      }
+    }
+  });
+  
+  return enums;
+}

--- a/lib/utils/file-reader.ts
+++ b/lib/utils/file-reader.ts
@@ -6,6 +6,7 @@ import { parseAST } from "./parser";
 import { anyType } from "../smells/any-type";
 import { nonNullAssertions } from "../smells/non-null-assertions";
 import { missingUnionTypeAbstraction } from "../smells/missing-union-type-abstraction";
+import { enumImplicitValues } from "../smells/enum-implicit-values";
 
 async function* readFiles(dirname: string): AsyncGenerator<TSXFile> {
   if(!(await fs.access(dirname).then(() => true).catch(() => false))) {
@@ -36,8 +37,10 @@ export async function processFiles(path: string) {
     const anyTypeSmells = anyType(ast);
     const nonNullSmells = nonNullAssertions(ast);
     const missingUnionSmells = missingUnionTypeAbstraction(ast);
+    const enumImplicitSmells = enumImplicitValues(ast);
     console.log(anyTypeSmells);
     console.log(nonNullSmells);
     console.log(missingUnionSmells);
+    console.log(enumImplicitSmells);
   }
 }

--- a/test/components/Enum.tsx
+++ b/test/components/Enum.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+enum Suit {
+  Hearts,
+  Diamonds,
+  Clubs,
+  Spades
+}
+
+export function Component() {
+  return(
+    <div>
+    </div>
+  )
+}

--- a/test/enum-implicit-values.spec.ts
+++ b/test/enum-implicit-values.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "vitest"
+import { parseAST } from "../lib/utils/parser";
+import { mockEnumImplicitValues } from "./mocks/code-smells-mock";
+import { enumImplicitValues } from "../lib/smells/enum-implicit-values";
+
+describe("Enum Implicit Values", () => {
+  test("should return an occurrence of Enum Implicit Values", () => {
+    const expectedOutput = [
+      { start: 3, end: 8, filename: 'test/components/Enum.tsx' }
+    ];
+
+    const ast = parseAST(mockEnumImplicitValues);
+
+    expect(enumImplicitValues(ast)).toEqual(expectedOutput);
+  });
+});

--- a/test/missing-union-type-abstraction.spec.ts
+++ b/test/missing-union-type-abstraction.spec.ts
@@ -4,7 +4,7 @@ import { mockMissingUnionTypeAbstraction } from "./mocks/code-smells-mock";
 import { missingUnionTypeAbstraction } from "../lib/smells/missing-union-type-abstraction";
 
 describe("Missing Union Type Abstraction", () => {
-  test("should return a occurrence of Missing Union Type Abstraction", () => {
+  test("should return an occurrence of Missing Union Type Abstraction", () => {
     const expectedOutput = [
       {
         members: [ 'circle', 'square' ],

--- a/test/mocks/code-smells-mock.ts
+++ b/test/mocks/code-smells-mock.ts
@@ -54,3 +54,22 @@ export const mockMissingUnionTypeAbstraction = {
     '  }\n' +
     '}'
 }
+
+export const mockEnumImplicitValues = {
+  path: 'test/components/Enum.tsx',
+  content: 'import React from "react";\n' +
+    '\n' +
+    'enum Suit {\n' +
+    '  Hearts,\n' +
+    '  Diamonds,\n' +
+    '  Clubs,\n' +
+    '  Spades\n' +
+    '}\n' +
+    '\n' +
+    'export function Component() {\n' +
+    '  return(\n' +
+    '    <div>\n' +
+    '    </div>\n' +
+    '  )\n' +
+    '}'
+}


### PR DESCRIPTION
## Context

The `enumImplicitValues` function traverses the AST in search of nodes that possess TSEnumDeclaration as their type. Then, verify that all members of the enum have constant values. If not, catch the smell.