### PR TITLE
smells: multiple booleans for state

### DIFF
--- a/lib/smells/multiple-booleans-for-state.ts
+++ b/lib/smells/multiple-booleans-for-state.ts
@@ -1,0 +1,27 @@
+import { ParseResult } from "@babel/parser";
+import traverse from "@babel/traverse";
+import { File, isBooleanLiteral } from "@babel/types";
+import { SourceLocation } from "../types";
+
+export const multipleBooleansForState = (ast: ParseResult<File>) => {
+  const states: SourceLocation[] = [];
+
+  traverse(ast, {
+    CallExpression(path) {
+      if (
+        path.node.callee.type === "Identifier" || path.node.callee.type === "MemberExpression" &&
+        path.node.callee.name === "useState" &&
+        path.node.arguments.length > 0 &&
+        isBooleanLiteral(path.node.arguments[0])
+      ) {
+        states.push({
+          start: path.node.callee.loc?.start.line,
+          end: path.node.callee.loc?.end.line,
+          filename: path.node.callee.loc?.filename
+        });
+      }
+    }
+  });
+
+  return states.length > 4 ? states : []
+}

--- a/lib/utils/file-reader.ts
+++ b/lib/utils/file-reader.ts
@@ -7,6 +7,7 @@ import { anyType } from "../smells/any-type";
 import { nonNullAssertions } from "../smells/non-null-assertions";
 import { missingUnionTypeAbstraction } from "../smells/missing-union-type-abstraction";
 import { enumImplicitValues } from "../smells/enum-implicit-values";
+import { multipleBooleansForState } from "../smells/multiple-booleans-for-state";
 
 async function* readFiles(dirname: string): AsyncGenerator<TSXFile> {
   if(!(await fs.access(dirname).then(() => true).catch(() => false))) {
@@ -38,9 +39,11 @@ export async function processFiles(path: string) {
     const nonNullSmells = nonNullAssertions(ast);
     const missingUnionSmells = missingUnionTypeAbstraction(ast);
     const enumImplicitSmells = enumImplicitValues(ast);
+    const multipleBooleansSmells = multipleBooleansForState(ast);
     console.log(anyTypeSmells);
     console.log(nonNullSmells);
     console.log(missingUnionSmells);
     console.log(enumImplicitSmells);
+    console.log(multipleBooleansSmells);
   }
 }

--- a/test/components/MultipleBooleans.tsx
+++ b/test/components/MultipleBooleans.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { useState } from "react";
+
+function MultipleBooleans() { 
+  const [isOpen, setIsOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasError, setHasError] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  return (
+    <div></div>
+  )
+}

--- a/test/mocks/code-smells-mock.ts
+++ b/test/mocks/code-smells-mock.ts
@@ -73,3 +73,22 @@ export const mockEnumImplicitValues = {
     '  )\n' +
     '}'
 }
+
+export const mockMultipleBooleansForState = {
+  path: 'test/components/MultipleBooleans.tsx',
+  content: 'import React from "react";\n' +
+    'import { useState } from "react";\n' +
+    '\n' +
+    'function MultipleBooleans() { \n' +
+    '  const [isOpen, setIsOpen] = useState(false);\n' +
+    '  const [isLoading, setIsLoading] = useState(false);\n' +
+    '  const [hasError, setHasError] = useState(false);\n' +
+    '  const [isEditing, setIsEditing] = useState(false);\n' +
+    '  const [isSaving, setIsSaving] = useState(false);\n' +
+    '  const [isDeleting, setIsDeleting] = useState(false);\n' +
+    '\n' +
+    '  return (\n' +
+    '    <div></div>\n' +
+    '  )\n' +
+    '}'
+}

--- a/test/multiple-booleans-for-state.spec.ts
+++ b/test/multiple-booleans-for-state.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "vitest";
+import { parseAST } from "../lib/utils/parser";
+import { mockMultipleBooleansForState } from "./mocks/code-smells-mock";
+import { multipleBooleansForState } from "../lib/smells/multiple-booleans-for-state";
+
+describe("Multiple Booleans for State", () => {
+  test("should return an occurrence of Multiple Booleans for State", () => {
+    const expectedOutput = [
+      {
+        start: 5,
+        end: 5,
+        filename: 'test/components/MultipleBooleans.tsx'
+      },
+      {
+        start: 6,
+        end: 6,
+        filename: 'test/components/MultipleBooleans.tsx'
+      },
+      {
+        start: 7,
+        end: 7,
+        filename: 'test/components/MultipleBooleans.tsx'
+      },
+      {
+        start: 8,
+        end: 8,
+        filename: 'test/components/MultipleBooleans.tsx'
+      },
+      {
+        start: 9,
+        end: 9,
+        filename: 'test/components/MultipleBooleans.tsx'
+      },
+      {
+        start: 10,
+        end: 10,
+        filename: 'test/components/MultipleBooleans.tsx'
+      }
+    ];
+
+    const ast = parseAST(mockMultipleBooleansForState);
+
+    expect(multipleBooleansForState(ast)).toEqual(expectedOutput);
+  });
+});


### PR DESCRIPTION
## Context

The `multipleBooleansForState` function traverses the AST in search of nodes that possess CallExpression as their type. Then, if the callee is an Identifier or MemberExpression, the name is useState, and the argument is a boolean, capture the start and end lines and calculate the thresholds.